### PR TITLE
Use bash shebang and GNU sed syntax

### DIFF
--- a/decompile.sh
+++ b/decompile.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if ! [ "$1" ]; then
     echo "usage decompile: $0 <file.apk>"

--- a/fix.sh
+++ b/fix.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # if ! [ "$1" ]; then
 #     echo "usage to recompile: $0 <file.apk>"
@@ -48,8 +48,8 @@ apps=(
 echo "Removing blacklisted apps"
 
 for app in "${apps[@]}"; do
-    find . -type f -name "$FOO.smali" -print0 | xargs -0 sed -i '' -e "s/\"$app\"/\"\"/g";
-    find . -type f -name "$BAR.smali" -print0 | xargs -0 sed -i '' -e "s/\"$app\"/\"\"/g";
+    find . -type f -name "$FOO.smali" -print0 | xargs -0 sed -i -e "s/\"$app\"/\"\"/g";
+    find . -type f -name "$BAR.smali" -print0 | xargs -0 sed -i -e "s/\"$app\"/\"\"/g";
 done
 
 echo "Blacklisted apps removed"
@@ -81,8 +81,8 @@ paths=(
 echo "Removing paths"
 
 for path in "${paths[@]}"; do
-    find . -type f -name "$FOO.smali" -print0 | xargs -0 sed -i '' -e "s+\"$path\"+\"\"+g";
-    find . -type f -name "$BAR.smali" -print0 | xargs -0 sed -i '' -e "s+\"$path\"+\"\"+g";
+    find . -type f -name "$FOO.smali" -print0 | xargs -0 sed -i -e "s+\"$path\"+\"\"+g";
+    find . -type f -name "$BAR.smali" -print0 | xargs -0 sed -i -e "s+\"$path\"+\"\"+g";
 done
 
 echo "Paths removed"
@@ -102,8 +102,8 @@ suPaths=(
 echo "Removing SU paths"
 
 for suPath in "${suPaths[@]}"; do 
-    find . -type f -name "$FOO.smali" -print0 | xargs -0 sed -i '' -e "s+\"$suPath\"+\"\"+g";
-    find . -type f -name "$BAR.smali" -print0 | xargs -0 sed -i '' -e "s+\"$suPath\"+\"\"+g";
+    find . -type f -name "$FOO.smali" -print0 | xargs -0 sed -i -e "s+\"$suPath\"+\"\"+g";
+    find . -type f -name "$BAR.smali" -print0 | xargs -0 sed -i -e "s+\"$suPath\"+\"\"+g";
 done
 
 miscs=(
@@ -112,8 +112,8 @@ miscs=(
 )
 
 for misc in "${miscs[@]}"; do 
-    find . -type f -name "$FOO.smali" -print0 | xargs -0 sed -i '' -e "s+\"$misc\"+\"\"+g";
-    find . -type f -name "$BAR.smali" -print0 | xargs -0 sed -i '' -e "s+\"$misc\"+\"\"+g";
+    find . -type f -name "$FOO.smali" -print0 | xargs -0 sed -i -e "s+\"$misc\"+\"\"+g";
+    find . -type f -name "$BAR.smali" -print0 | xargs -0 sed -i -e "s+\"$misc\"+\"\"+g";
 done
 
 echo "SU paths removed"

--- a/recompile.sh
+++ b/recompile.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if ! [ "$1" ]; then
     echo "usage to recompile: $0 <file.apk>"


### PR DESCRIPTION
(Correct me if I'm wrong, please!)

Unfortunately I don't believe your modification script works in Ubuntu (I tested) or most Linux distributions (I haven't tested). This is because the `sed` syntax differs in MacOS and GNU. In particular, `sed -i ''` on a Mac is equivalent to `sed -i` in GNU. Best practice way to solve this IMO would be to use the GNU version of `sed` as standard and use `brew` to get GNU `sed` on your Mac, but I don't want to tell you which versions of what to use! But also, adding a load of `if` statements would be a pain...

The other thing is the shebang uses `sh` but this (on Linux) doesn't support the array syntax you use. So I think this could be changed to bash.

I did have to run `./fix.sh bank.apk Const b` in order to get this to work - I am interested in how this is supposed to work without those arguments specified?

Do what you will, but I've made a PR on your repository if you want to make the script follow the GNU `sed` syntax and use bash, which I think would make it easier to run :) I've mentioned a few other things here that might be good to just put in the README, up to you of course.

Also, a final note to Linux users, the `apktool` version available through `sudo apt install apktools` (`2.3.4`) does *not* recompile the package succesfully (on my Ubuntu system anyways). So make sure to download the latest version and install it manually. I actually just put it in the same directory as the script and changed all the `apktool` lines in the scripts to `./apktool`. I also changed the `./zipalign` bit to `zipalign` as I had a version of this installed on my system and no file was provided in the repo. Everything worked then!

Really apprecate your work @ppamorim !